### PR TITLE
viewing-party: change submission page main -> master

### DIFF
--- a/viewing-party/submit.md
+++ b/viewing-party/submit.md
@@ -23,7 +23,7 @@ How to submit using Git for the first time:
     - Add all files to staging with `$ git add -A`
     - Make a commit with a meaningful commit message `$ git commit -m "Your message here"`
 1. Push your project commit to your own project repo
-    - Run `$ git push` or `$ git push origin main`
+    - Run `$ git push` or `$ git push origin master`
 1. Get the URL of _**your own**_ project repo.
 
 Place the URL of your own project repo here.
@@ -57,9 +57,9 @@ How to make a Pull Request on GitHub for the first time:
 1. Begin a new pull request by clicking "New Pull Request"
 1. Configure this PR so it compares your project against Ada's:
     - **base repository** is `<some-ada-repo>/<project-name>`
-    - **base** is `main`
+    - **base** is `master`
     - **head repository** is `<your-username>/<project-name>`
-    - **compare** is `main`
+    - **compare** is `master`
 1. Add more details by clicking "Create pull request":
     - For the PR title, include:
         - Your class name


### PR DESCRIPTION
I went ahead and updated to assume the default branch on their fork will be `master` as well. Let me know if you don't think that's what we want for some reason, but it seems like that's what GitHub will default to, since it'll emulate what it forked from.

For context on change, here's what Simon had to say in Slack:

The submission instructors for Viewing Party say that a PR should be made between <studentrepo>/main to Ada-C15/main . However, this is wrong, it should be made to Ada-C15/master.
This is because we discovered Learn has a limitation, and their autograded tests need to be on the master branch. Although theoretically, the PR COULD be made against Ada-C15/main (since it's just for instructor grading), it'll be weird if master and main end up diverging IMO, and it'll be more reliable to tell students to point it to master