### PR TITLE
hotfix: updates main references to master

### DIFF
--- a/ada-project-practices/how-to-submit.md
+++ b/ada-project-practices/how-to-submit.md
@@ -18,7 +18,7 @@ Unless there are other directions, the typical flow for submitting a project is
     - Add all files to staging with `$ git add -A`
     - Make a commit with a meaningful commit message `$ git commit -m "Your message here"`
 1. Push your project commit to your own project repo
-    - Run `$ git push` or `$ git push origin main`
+    - Run `$ git push` or `$ git push origin master`
 
 ### Getting Code onto GitHub
 
@@ -40,9 +40,9 @@ Use your git skills to make a git history and push it up!
 1. Begin a new pull request by clicking "New Pull Request"
 1. Configure this PR so it compares your project against Ada's:
     - **base repository** is `<some-ada-repo>/<project-name>`
-    - **base** is `main`
+    - **base** is `master`
     - **head repository** is `<your-username>/<project-name>`
-    - **compare** is `main`
+    - **compare** is `master`
 1. Add more details by clicking "Create pull request":
     - For the PR title, include:
         - Your class name


### PR DESCRIPTION
The general how to submit instructions still reference pushing to main, though we need to use master for the automated tests.

The version of this file included with viewing party was update to refer to master, but this shared copy was not.