### PR TITLE
add submission troubleshooting callout

### DIFF
--- a/react-chat-log/submit.md
+++ b/react-chat-log/submit.md
@@ -22,6 +22,15 @@ The URL to your project repo on GitHub: https://github.com/<your-username>/<proj
 
 ##### !end-placeholder
 ### !end-challenge
+
+<!-- available callout types: info, success, warning, danger, secondary, star  -->
+### !callout-warning
+
+## Submission Troubleshooting
+
+If your submission never completes, there might be warnings preventing it. Make sure to remove any `console.log` statements in your code to make it easier to see any warnings that may be reported during the tests (even if the tests appear to be passing). Address any warnings being reported, push your changes, then try to submit again!
+
+### !end-callout
 <!-- prettier-ignore-end -->
 
 ## Submit Project for Feedback


### PR DESCRIPTION
Ansel found that the submission spun when there was a warning about Invalid proptypes and a missing key. These warnings were hard to see because of a console.log. Adding a callout to help students troubleshoot if this comes up (Ansel's words, thanks!)