### PR TITLE
Ac2 Precourse Projects DO NOT MERGE

### DIFF
--- a/adagrams/intro.md
+++ b/adagrams/intro.md
@@ -5,5 +5,5 @@ This project is optional to complete
 | --------------------- | ------------------------------------ |
 | Original project repo | [https://github.com/ada-ac2/adagrams-py](https://github.com/ada-ac2/adagrams-py) |
 | Project details       | [https://github.com/ada-ac2/adagrams-py](https://github.com/ada-ac2/adagrams-py) |
-| Should you fork this? | Yes |
+| Should you fork this? | Yes (Check project details) |
 | Submission method     | Learn                                |

--- a/adagrams/intro.md
+++ b/adagrams/intro.md
@@ -5,5 +5,5 @@ This project is optional to complete
 | --------------------- | ------------------------------------ |
 | Original project repo | [https://github.com/ada-ac2/adagrams-py](https://github.com/ada-ac2/adagrams-py) |
 | Project details       | [https://github.com/ada-ac2/adagrams-py](https://github.com/ada-ac2/adagrams-py) |
-| Should you fork this? | Yes (Check project details for fork instructions specific to working in a team)          |
+| Should you fork this? | Yes |
 | Submission method     | Learn                                |

--- a/adagrams/intro.md
+++ b/adagrams/intro.md
@@ -1,8 +1,9 @@
 # Project: Adagrams
+This project is optional to complete
 
 | Logistics             | Details                              |
 | --------------------- | ------------------------------------ |
-| Original project repo | [https://github.com/Ada-C18/adagrams-py](https://github.com/Ada-C18/adagrams-py) |
-| Project details       | [https://github.com/Ada-C18/adagrams-py](https://github.com/Ada-C18/adagrams-py) |
+| Original project repo | [https://github.com/ada-ac2/adagrams-py](https://github.com/ada-ac2/adagrams-py) |
+| Project details       | [https://github.com/ada-ac2/adagrams-py](https://github.com/ada-ac2/adagrams-py) |
 | Should you fork this? | Yes (Check project details for fork instructions specific to working in a team)          |
 | Submission method     | Learn                                |

--- a/adagrams/submit.md
+++ b/adagrams/submit.md
@@ -7,7 +7,7 @@
 * type: testable-project
 * id: b8a12109-a8d6-40d4-b7f7-900e32cd8962
 * title: Fork URL for Grading
-* upstream: https://github.com/AdaGold/adagrams-py
+* upstream: https://github.com/ada-ac2/adagrams-py
 * validate_fork: false
 * points: 0
 * topics: python, python-oop

--- a/adagrams/submit.md
+++ b/adagrams/submit.md
@@ -13,12 +13,12 @@
 * topics: python, python-oop
 ##### !question
 
-Place the URL of your team project repo here. Review instructions in the [How to Submit](../ada-project-practices/how-to-submit.md) repo if needed.
+Place the URL of your project repo here. Review instructions in the [How to Submit](../ada-project-practices/how-to-submit.md) repo if needed.
 
 ##### !end-question
 ##### !placeholder
 
-The URL to your team project repo on GitHub: https://github.com/<your-username>/<project-name>
+The URL to your project repo on GitHub: https://github.com/<your-username>/<project-name>
 
 ##### !end-placeholder
 ### !end-challenge
@@ -42,7 +42,7 @@ Make a pull request against the original project repo. Place the URL of the pull
 ##### !end-question
 ##### !placeholder
 
-The URL to your team pull request: https://github.com/<some-ada-repo>/<project-name>/pulls
+The URL to your pull request: https://github.com/<some-ada-repo>/<project-name>/pulls
 
 ##### !end-placeholder
 ##### !answer
@@ -53,35 +53,3 @@ The URL to your team pull request: https://github.com/<some-ada-repo>/<project-n
 ### !end-challenge
 <!-- prettier-ignore-end -->
 
-## Reflect on Pair Programming
-
-<!--BEGIN CHALLENGE-->
-
-### !challenge
-
-* type: paragraph
-* id: 0a403185-cde2-4a5b-9bfb-7333ff3db9f9
-* title: Reflection
-
-##### !question
-
-Reflect on the pair programming experience.  Respond to the following prompts:
-
-- How was working in a pair similar or different to working individually?
-- What were pair programming strategies that you found effective?
-- What were some of the challenges of working in a pair that you had to overcome?
-- How did pair programming impact your learning (positive or negative)?
-
-
-##### !end-question
-
-##### !placeholder
-
-<!--Placeholder text-->
-
-##### !end-placeholder
-
-
-### !end-challenge
-
-<!--END CHALLENGE-->

--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,7 @@ Standards:
         UID: 79b4aad1f3dbbcd07eb6010a6feb8c9e
         Path: /viewing-party/submit.md
   -
-    Title: AdaGrams
+    Title: Optional - AdaGrams
     Description: "Unit 1 Project: Programming Fundamentals, Pair Programming"
     UID: d82288a7-65ae-4059-a7e4-0c6abd263d0f
     SuccessCriteria:

--- a/config.yaml
+++ b/config.yaml
@@ -13,7 +13,7 @@ Standards:
         Path: /ada-project-practices/how-to-submit.md
   -
     Title: Viewing Party
-    Description: "Unit 1 Project: Programming Fundamentals"
+    Description: "Precourse Project: Programming Fundamentals"
     UID: 687ba6c9a090110d939df3281701e530
     SuccessCriteria:
       - success criteria
@@ -28,7 +28,7 @@ Standards:
         Path: /viewing-party/submit.md
   -
     Title: Optional - AdaGrams
-    Description: "Unit 1 Project: Programming Fundamentals, Pair Programming"
+    Description: "Precourse Optional Project: Programming Fundamentals, Pair Programming"
     UID: d82288a7-65ae-4059-a7e4-0c6abd263d0f
     SuccessCriteria:
       - success criteria

--- a/viewing-party/intro.md
+++ b/viewing-party/intro.md
@@ -4,7 +4,7 @@
 
 | Logistics             | Details                                  |
 | --------------------- | ---------------------------------------- |
-| Original project repo | https://github.com/Ada-C18/viewing-party |
-| Project details       | https://github.com/Ada-C18/viewing-party |
+| Original project repo | https://github.com/ada-ac2/viewing-party |
+| Project details       | https://github.com/ada-ac2/viewing-party |
 | Should you fork this? | Yes (Check project details)              |
 | Submission method     | Learn                                    |

--- a/viewing-party/submit.md
+++ b/viewing-party/submit.md
@@ -7,7 +7,7 @@
 * type: testable-project
 * id: BxHGhu
 * title: Fork URL for Grading
-* upstream: https://github.com/AdaGold/viewing-party
+* upstream: https://github.com/ada-ac2/viewing-party
 * validate_fork: false
 * points: 0
 * topics: python, fundamentals, data structures


### PR DESCRIPTION
Summary of Changes:
- config.yaml marks Adagrams as optional
- config.yaml marks Adagrams and Viewing Party as Precourse Projects
- Update project links and upstream test branch for Adagrams to AC2 branch
- Remove references to pair programming/team projects in Adagrams checkpoint
- Update project links and upstream test branch for Viewing Party to AC2 branch