### PR TITLE
Remove explicit reference to Heroku on full stack inspo board for future cohorts

### DIFF
--- a/full-stack-inspiration-board/submit.md
+++ b/full-stack-inspiration-board/submit.md
@@ -100,7 +100,7 @@ The URL to your team's pull request: https://github.com/<some-ada-repo>/<project
 ### !end-challenge
 <!-- prettier-ignore-end -->
 
-## Deployed on Heroku
+## Deployment Links
 
 <!-- prettier-ignore-start -->
 ### !challenge


### PR DESCRIPTION
Moves to generic title "Deployment Links" so this does not need to be updated if we change deployment platforms in the future.