### PR TITLE
Add tool usage reflection questions to remaining projects

### DIFF
--- a/adagrams/submit.md
+++ b/adagrams/submit.md
@@ -117,7 +117,7 @@ My reflections on the questions above are...
 ##### !question
 
 If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
-- If there are multiple chats, please separate each URL with a space. 
+- If there are multiple chats, please place each URL on a new line. 
 
 Please respond "N/A" if you did not use any AI resources.
 

--- a/group-fansite/submit.md
+++ b/group-fansite/submit.md
@@ -148,7 +148,7 @@ My reflections on the questions above are...
 ##### !question
 
 If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
-- If there are multiple chats, please separate each URL with a space. 
+- If there are multiple chats, please place each URL on a new line. 
 
 Please respond "N/A" if you did not use any AI resources.
 

--- a/group-fansite/submit.md
+++ b/group-fansite/submit.md
@@ -114,3 +114,69 @@ My reflections on the questions above are...
 ##### !end-placeholder
 ### !end-challenge
 <!-- prettier-ignore-end -->
+
+## Tool Usage Reflections
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: d8a5f4f0-1f51-4bad-beeb-f3b29bfb5541
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please reflect on your usage and answer the following questions:
+- How did you confirm that the information the AI shared was up to date and accurate?
+- What suggestions did you find useful or think would be helpful to keep in mind for the future?
+- What suggestions were not useful or relevant?
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+My reflections on the questions above are...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 19a65548-efcf-40f4-a63a-a780a294dd2e
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
+- If there are multiple chats, please separate each URL with a space. 
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+Add AI chat URLs here if relevant.
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 35e045ff-ba2d-4482-90e3-12430eac96ae
+* title: Tool Usage Reflection
+##### !question
+
+Outside of VS Code & Python, were there any other resources or tools you used while working on this project? 
+
+In the box below, please share which resources were most useful and why.
+
+##### !end-question
+##### !placeholder
+
+The resources I found most useful were...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->

--- a/js-adagrams/submit.md
+++ b/js-adagrams/submit.md
@@ -2,6 +2,7 @@
 
 ## Submit Project for Grading
 
+<!-- prettier-ignore-start -->
 ### !challenge
 * type: testable-project
 * id: a5bcb614-702c-4df8-a7a3-d8c6401691ae
@@ -10,66 +11,55 @@
 * validate_fork: false
 * points: 1
 * topics: javascript
-
 ##### !question
 
 Please paste a link to your repo here.
 
 ##### !end-question
-
 ##### !placeholder
 
 The URL to your project repo on GitHub: https://github.com/<your-username>/<project-name>
 
 ##### !end-placeholder
 ### !end-challenge
-<!-- ======================= END CHALLENGE ======================= -->
+<!-- prettier-ignore-end -->
 
 ## Submit Project for Feedback
 
 Instructors provide code feedback through pull requests.
 
-<!-- >>>>>>>>>>>>>>>>>>>>>> BEGIN CHALLENGE >>>>>>>>>>>>>>>>>>>>>> -->
-
+<!-- prettier-ignore-start -->
 ### !challenge
-
 * type: short-answer
 * id: 05e07834-6de4-4ddd-88d5-53601d4b5bb1
 * title: Pull Request for Feedback
 * points: 3
 * topics: javascript
-
 ##### !question
 
 Make a pull request against the original project repo. Place the URL of the pull request here.
 
 ##### !end-question
-
 ##### !placeholder
 
 The URL to your pull request: https://github.com/<some-ada-repo>/<project-name>/pulls
 
 ##### !end-placeholder
-
 ##### !answer
 
 /.+/
 
 ##### !end-answer
 ### !end-challenge
+<!-- prettier-ignore-end -->
 
-<!-- ======================= END CHALLENGE ======================= -->
-
-<!-- >>>>>>>>>>>>>>>>>>>>>> BEGIN CHALLENGE >>>>>>>>>>>>>>>>>>>>>> -->
-
+<!-- prettier-ignore-start -->
 ### !challenge
-
 * type: paragraph
 * id: d6f8779c-040d-4277-9c08-d66d1e123f32
 * title: Reflection
 * points: 1
 * topics: javascript
-
 ##### !question
 
 Reflect on your process and your learning by answering one or more of the following questions:
@@ -81,14 +71,56 @@ Reflect on your process and your learning by answering one or more of the follow
 1. What is something to focus on in learning JavaScript in the coming week?
 
 ##### !end-question
-
 ##### !placeholder
 
 Reflection
 
 ##### !end-placeholder
-
 ### !end-challenge
+<!-- prettier-ignore-end -->
 
-<!-- ======================= END CHALLENGE ======================= -->
+## Tool Usage Reflections
 
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: f7ea1925-08a1-418c-8355-71decb242e4c
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please reflect on your usage and answer the following questions:
+- How did you confirm that the information the AI shared was up to date and accurate?
+- What suggestions did you find useful or think would be helpful to keep in mind for the future?
+- What suggestions were not useful or relevant?
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+My reflections on the questions above are...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: c017ca25-9bc2-4b71-a94c-d13465acfeae
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
+- If there are multiple chats, please place each URL on a new line. 
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+Add AI chat URLs here if relevant.
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->

--- a/react-chat-log/submit.md
+++ b/react-chat-log/submit.md
@@ -90,3 +90,69 @@ https://your-app-name.github.io
 ##### !end-answer
 ### !end-challenge
 <!-- prettier-ignore-end -->
+
+## Tool Usage Reflections
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 59d6fa1b-aba3-407d-a908-18ad6d8cc84b
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please reflect on your usage and answer the following questions:
+- How did you confirm that the information the AI shared was up to date and accurate?
+- What suggestions did you find useful or think would be helpful to keep in mind for the future?
+- What suggestions were not useful or relevant?
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+My reflections on the questions above are...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 87a14dff-3cdd-4454-9ce3-60469530941f
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
+- If there are multiple chats, please place each URL on a new line. 
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+Add AI chat URLs here if relevant.
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: a3188445-73f1-433b-b2c2-0159d0eaed6c
+* title: Tool Usage Reflection
+##### !question
+
+Outside of VS Code & Python, were there any other resources or tools you used while working on this project? 
+
+In the box below, please share which resources were most useful and why.
+
+##### !end-question
+##### !placeholder
+
+The resources I found most useful were...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->

--- a/swap-meet/submit.md
+++ b/swap-meet/submit.md
@@ -77,3 +77,69 @@ My reflections on the questions above are...
 ##### !end-placeholder
 ### !end-challenge
 <!-- prettier-ignore-end -->
+
+## Tool Usage Reflections
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: a7bc1698-5999-4706-99eb-17dc1dff52df
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please reflect on your usage and answer the following questions:
+- How did you confirm that the information the AI shared was up to date and accurate?
+- What suggestions did you find useful or think would be helpful to keep in mind for the future?
+- What suggestions were not useful or relevant?
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+My reflections on the questions above are...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 35cd6075-9e89-4d10-b0ac-317d2e20c7d8
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
+- If there are multiple chats, please separate each URL with a space. 
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+Add AI chat URLs here if relevant.
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 09dba6f6-50f9-4b38-892d-660c5fbfd543
+* title: Tool Usage Reflection
+##### !question
+
+Outside of VS Code & Python, were there any other resources or tools you used while working on this project? 
+
+In the box below, please share which resources were most useful and why.
+
+##### !end-question
+##### !placeholder
+
+The resources I found most useful were...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->

--- a/swap-meet/submit.md
+++ b/swap-meet/submit.md
@@ -111,7 +111,7 @@ My reflections on the questions above are...
 ##### !question
 
 If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
-- If there are multiple chats, please separate each URL with a space. 
+- If there are multiple chats, please place each URL on a new line. 
 
 Please respond "N/A" if you did not use any AI resources.
 

--- a/task-list-api/submit.md
+++ b/task-list-api/submit.md
@@ -136,7 +136,7 @@ My reflections on the questions above are...
 ##### !question
 
 If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
-- If there are multiple chats, please separate each URL with a space. 
+- If there are multiple chats, please place each URL on a new line. 
 
 Please respond "N/A" if you did not use any AI resources.
 

--- a/task-list-api/submit.md
+++ b/task-list-api/submit.md
@@ -102,3 +102,69 @@ If this project does not have any completed optional enhancements, please enter 
 ##### !end-question
 ### !end-challenge
 <!-- prettier-ignore-end -->
+
+## Tool Usage Reflections
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 2a7dd83a-1258-47c4-b76c-dad153384699
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please reflect on your usage and answer the following questions:
+- How did you confirm that the information the AI shared was up to date and accurate?
+- What suggestions did you find useful or think would be helpful to keep in mind for the future?
+- What suggestions were not useful or relevant?
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+My reflections on the questions above are...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 70f90c6f-b49e-40da-965a-f713959d6f7a
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
+- If there are multiple chats, please separate each URL with a space. 
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+Add AI chat URLs here if relevant.
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 7c962d36-8ebe-46c5-9bf3-fdbba41e009d
+* title: Tool Usage Reflection
+##### !question
+
+Outside of VS Code & Python, were there any other resources or tools you used while working on this project? 
+
+In the box below, please share which resources were most useful and why.
+
+##### !end-question
+##### !placeholder
+
+The resources I found most useful were...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->

--- a/viewing-party/submit.md
+++ b/viewing-party/submit.md
@@ -77,3 +77,69 @@ My reflections on the questions above are...
 ##### !end-placeholder
 ### !end-challenge
 <!-- prettier-ignore-end -->
+
+## Tool Usage Reflections
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 386c1195-eb38-4761-825e-8a3855439f3f
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please reflect on your usage and answer the following questions:
+- How did you confirm that the information the AI shared was up to date and accurate?
+- What suggestions did you find useful or think would be helpful to keep in mind for the future?
+- What suggestions were not useful or relevant?
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+My reflections on the questions above are...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 996a49bb-1d2c-46f7-8256-1ea38eca65cc
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
+- If there are multiple chats, please separate each URL with a space. 
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+Add AI chat URLs here if relevant.
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 9318cc31-c300-42c4-8469-52305dc1861a
+* title: Tool Usage Reflection
+##### !question
+
+Outside of VS Code & Python, were there any other resources or tools you used while working on this project? 
+
+In the box below, please share which resources were most useful and why.
+
+##### !end-question
+##### !placeholder
+
+The resources I found most useful were...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->

--- a/viewing-party/submit.md
+++ b/viewing-party/submit.md
@@ -111,7 +111,7 @@ My reflections on the questions above are...
 ##### !question
 
 If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
-- If there are multiple chats, please separate each URL with a space. 
+- If there are multiple chats, please place each URL on a new line. 
 
 Please respond "N/A" if you did not use any AI resources.
 

--- a/weather-report/submit.md
+++ b/weather-report/submit.md
@@ -82,3 +82,69 @@ My reflections on the questions above are...
 ##### !end-placeholder
 ### !end-challenge
 <!-- prettier-ignore-end -->
+
+## Tool Usage Reflections
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 62da2d51-23ed-4a0d-ac3c-e3fb6fe2e732
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please reflect on your usage and answer the following questions:
+- How did you confirm that the information the AI shared was up to date and accurate?
+- What suggestions did you find useful or think would be helpful to keep in mind for the future?
+- What suggestions were not useful or relevant?
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+My reflections on the questions above are...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 3c5562fd-c1f7-4475-9be5-cbff927876f1
+* title: Tool Usage Reflection
+##### !question
+
+If you used AI tools while working on this project, please share links to the AI chats you used to discuss the project below. 
+- If there are multiple chats, please place each URL on a new line. 
+
+Please respond "N/A" if you did not use any AI resources.
+
+##### !end-question
+##### !placeholder
+
+Add AI chat URLs here if relevant.
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+### !challenge
+* type: paragraph
+* id: 6074a4c1-955e-4946-970e-231faac20918
+* title: Tool Usage Reflection
+##### !question
+
+Outside of VS Code & Python, were there any other resources or tools you used while working on this project? 
+
+In the box below, please share which resources were most useful and why.
+
+##### !end-question
+##### !placeholder
+
+The resources I found most useful were...
+
+##### !end-placeholder
+### !end-challenge
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/1/181459410160484/project/1205655776549324/task/1209973030564735?focus=true)

**Notes**
- Does not update Solar System & Task List Front End since we check those off in class rather than turning in on Learn now.
- Does not update Full Stack Inspo Board since we give very light feedback.
- JS Adagrams: Cut the last tool reflection question asking about other tools/resources used to avoid redundancy. The submission already had a reflection question around differences in what they needed to research and resources. 

**Changes**
- Updates wording on AI chat links question to now request that if there are multiple AI chats each URL goes on its own line. (Since Adagrams had it's own PR to review the reflection questions, only this line is changed here).
- Add Tool Usage questions to:
  - Unit 1
    - Viewing Party
    - Swap Meet 
  - Unit 2
    - Task List API
  - Unit 3
    - Group Fansite
    - JS Adagrams
    - Weather Report
    - React Chatlog 
